### PR TITLE
compatibility with GHC 8.4.x and foldl 1.3.x

### DIFF
--- a/src/Typed/Spreadsheet.hs
+++ b/src/Typed/Spreadsheet.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ApplicativeDo              #-}
+{-# LANGUAGE CPP              #-}
 
 -- | The following program:
 --
@@ -167,10 +168,20 @@ instance Applicative Updatable where
 
     Updatable mf <*> Updatable mx = Updatable (liftA2 (<*>) mf mx)
 
+#if MIN_VERSION_base(4,11,0)
+instance Semigroup a => Semigroup (Updatable a) where
+    (<>) = liftA2 (<>)
+
+instance Monoid a => Monoid (Updatable a) where
+    mempty = pure mempty
+
+#else
 instance Monoid a => Monoid (Updatable a) where
     mempty = pure mempty
 
     mappend = liftA2 mappend
+#endif
+
 
 instance IsString a => IsString (Updatable a) where
     fromString str = pure (fromString str)

--- a/typed-spreadsheet.cabal
+++ b/typed-spreadsheet.cabal
@@ -1,5 +1,5 @@
 Name: typed-spreadsheet
-Version: 1.1.2
+Version: 1.1.3
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
@@ -37,7 +37,7 @@ Library
         diagrams-cairo >= 1.3    && < 1.5 ,
         diagrams-gtk   >= 1.3    && < 1.5 ,
         diagrams-lib   >= 1.3    && < 1.5 ,
-        foldl          >= 1.1    && < 1.3 ,
+        foldl          >= 1.1    && < 1.4 ,
         gtk            >= 0.13   && < 0.15,
         microlens                   < 0.5 ,
         stm                         < 2.5 ,


### PR DESCRIPTION
Relaxed upper bound on `foldl` to work with 1.3.x and made changes to be compatible with GHC 8.4.x and `base` 4.11.x which introduced the `Semigroup` super class constraint for `Monoid`.

I build it on nix using GHC 8.2.2 and 8.4.3. 