### PR TITLE
Bump upper bounds on gtk to allow 0.15.x series

### DIFF
--- a/typed-spreadsheet.cabal
+++ b/typed-spreadsheet.cabal
@@ -38,7 +38,7 @@ Library
         diagrams-gtk   >= 1.3    && < 1.5 ,
         diagrams-lib   >= 1.3    && < 1.5 ,
         foldl          >= 1.1    && < 1.5 ,
-        gtk            >= 0.13   && < 0.15,
+        gtk            >= 0.13   && < 0.16,
         microlens                   < 0.5 ,
         stm                         < 2.6 ,
         text                        < 1.3 ,


### PR DESCRIPTION
0.15.4 is out. The 0.14.x ones were rejected by the solver for me on GHC
  8.8.3 and Cabal 3.0.1.0 - I think because of the Cabal version.
I built it against gtk-0.15.4, and the examples seem to work fine.